### PR TITLE
Update usage.rst

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -20,7 +20,8 @@ Run
 - `gpt-engineer projects/my-new-project`
   - (Note, `gpt-engineer --help` lets you see all available options. For example `--steps use_feedback` lets you improve/fix code in a project)
 
-By running gpt-engineer you agree to our [terms](https://github.com/AntonOsika/gpt-engineer/blob/main/TERMS_OF_USE.md).
+By running gpt-engineer you agree to our `terms <https://github.com/AntonOsika/gpt-engineer/blob/main/TERMS_OF_USE.md>`_
+.
 
 Results
 =======


### PR DESCRIPTION
Fix hyperlink format in .rst document

Corrected the syntax for the "terms" hyperlink in the reStructuredText file to adhere to .rst standards. This ensures proper rendering of the link in the documentation.