### PR TITLE
fix CLI parameter at doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ You can specify the "identity" of the AI agent by editing the files in the `prep
 
 Editing the `preprompts`, and evolving how you write the project prompt, is how you make the agent remember things between projects.
 
-You can also automatically copy all `preprompts` files into your project folder using the cli parameter `--use-custom-prepompts`. This way you can have custom preprompts for all of your projects without the need to edit the main files.
+You can also automatically copy all `preprompts` files into your project folder using the cli parameter `--use-custom-preprompts`. This way you can have custom preprompts for all of your projects without the need to edit the main files.
 
 You can also run with open source models, like WizardCoder. See the [documentation](https://gpt-engineer.readthedocs.io/en/latest/open_models.html) for example instructions.
 


### PR DESCRIPTION
"Thank you for providing such a great product. I found a typo in the doc while using it. I have confirmed that it works when using the CLI parameter --use-custom-preprompts. The basis for the correction is in the following section:

gpt_engineer/applications/cli/main.py
``` 
    use_custom_preprompts: bool = typer.Option(
        False,
        "--use-custom-preprompts",
        help="""Use your project's custom preprompts instead of the default ones.
          Copies all original preprompts to the project's workspace if they don't exist there.""",
    ),
```