### PR TITLE
Updated type hints and dictionary merging for Python 3.8 compatibility.

### DIFF
--- a/gpt_engineer/applications/cli/cli_agent.py
+++ b/gpt_engineer/applications/cli/cli_agent.py
@@ -113,7 +113,8 @@ class CliAgent(BaseAgent):
         entrypoint = gen_entrypoint(
             self.ai, files_dict, self.memory, self.preprompts_holder
         )
-        files_dict = FilesDict(files_dict | entrypoint)
+        combined_dict = {**files_dict, **entrypoint}
+        files_dict = FilesDict(combined_dict)
         files_dict = self.process_code_fn(
             self.ai,
             self.execution_env,
@@ -135,7 +136,8 @@ class CliAgent(BaseAgent):
             entrypoint = gen_entrypoint(
                 self.ai, files_dict, self.memory, self.preprompts_holder
             )
-            files_dict = FilesDict(files_dict | entrypoint)
+            combined_dict = {**files_dict, **entrypoint}
+            files_dict = FilesDict(combined_dict)
         files_dict = self.process_code_fn(
             self.ai,
             self.execution_env,

--- a/gpt_engineer/benchmark/run.py
+++ b/gpt_engineer/benchmark/run.py
@@ -1,13 +1,18 @@
 import time
 
+from typing import List, Optional
+
 from gpt_engineer.benchmark.types import Assertable, Benchmark, TaskResult
 from gpt_engineer.core.base_agent import BaseAgent
 from gpt_engineer.core.default.disk_execution_env import DiskExecutionEnv
 
 
 def run(
-    agent: BaseAgent, benchmark: Benchmark, task_name: str | None = None, verbose=False
-) -> list[TaskResult]:
+    agent: BaseAgent,
+    benchmark: Benchmark,
+    task_name: Optional[str] = None,
+    verbose=False,
+) -> List[TaskResult]:
     task_results = []
     for task in benchmark.tasks:
         t0 = time.time()

--- a/gpt_engineer/benchmark/types.py
+++ b/gpt_engineer/benchmark/types.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from subprocess import Popen
-from typing import Callable
+from typing import Callable, Dict, Optional
 
 from gpt_engineer.core.base_execution_env import BaseExecutionEnv
 from gpt_engineer.core.files_dict import FilesDict
@@ -21,9 +21,9 @@ class Assertable:
 
     files: FilesDict
     env: BaseExecutionEnv
-    process: Popen | None
-    stdout: str | None
-    stderr: str | None
+    process: Optional[Popen]
+    stdout: Optional[str]
+    stderr: Optional[str]
 
 
 Assertion = Callable[[Assertable], bool]
@@ -32,10 +32,10 @@ Assertion = Callable[[Assertable], bool]
 @dataclass
 class Task:
     name: str
-    initial_code: FilesDict | None
-    command: str | None
+    initial_code: Optional[FilesDict]
+    command: Optional[str]
     prompt: str
-    assertions: dict[str, Assertion] | None
+    assertions: Optional[Dict[str, Assertion]]
 
 
 @dataclass
@@ -44,7 +44,7 @@ class Benchmark:
 
     name: str
     tasks: list[Task]
-    timeout: int | None = None
+    timeout: Optional[int] = None
 
 
 @dataclass

--- a/gpt_engineer/core/default/simple_agent.py
+++ b/gpt_engineer/core/default/simple_agent.py
@@ -56,7 +56,8 @@ class SimpleAgent(BaseAgent):
         entrypoint = gen_entrypoint(
             self.ai, files_dict, self.memory, self.preprompts_holder
         )
-        files_dict = FilesDict(files_dict | entrypoint)
+        combined_dict = {**files_dict, **entrypoint}
+        files_dict = FilesDict(combined_dict)
         return files_dict
 
     def improve(


### PR DESCRIPTION
Hi @ATheorell,

I've recently made updates to the type hints and dictionary merging methods to ensure compatibility with Python 3.8. Following our discussion, it's now an opportune moment to update the PyPI package and README file. Let's indicate that this release is the latest version supporting Python 3.8 and 3.9, ensuring our users are informed of the enhancements and compatibility.
