### PR TITLE
Update Python in Dockerfile. 3.10->3.11

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM python:3.11-slim
 
 RUN apt-get update \
  && apt-get install -y sudo tk tcl


### PR DESCRIPTION
I encountered problems when running Python 3.10 following the instructions, but everything worked smoothly with Python 3.11. I recommend upgrading to this version.