### PR TITLE
python:3.11-slim no longer has gcc

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.11-slim
 
 RUN apt-get update \
- && apt-get install -y sudo tk tcl
+ && apt-get install -y sudo tk tcl gcc
 
 WORKDIR /app
 


### PR DESCRIPTION
pyton3.11-slim no longer includes gcc. 

Add gcc via apt install instead of finding an alternative (possibly less slim) base Docker image