### PR TITLE
Adding toml as dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ tiktoken = ">=0.0.4"
 tabulate = "0.9.0"
 python-dotenv = ">=0.21.0"
 langchain = ">=0.0.335"
+toml = ">=0.10.2"
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=7.3.1"
@@ -72,7 +73,7 @@ gpte_test_application = 'tests.caching_main:app'
 
 [tool.poetry.extras]
 test = ["pytest", "pytest-cov"]
-doc = ["autodoc_pydantic", "myst_parser", "nbsphinx", "sphinx", "sphinx-autobuild", "sphinx_book_theme", "sphinx_rtd_theme", "sphinx-typlog-theme", "sphinx-panels", "toml", "myst-nb", "linkchecker", "sphinx-copybutton", "markdown-include", "sphinx_copybutton"]
+doc = ["autodoc_pydantic", "myst_parser", "nbsphinx", "sphinx", "sphinx-autobuild", "sphinx_book_theme", "sphinx_rtd_theme", "sphinx-typlog-theme", "sphinx-panels", "myst-nb", "linkchecker", "sphinx-copybutton", "markdown-include", "sphinx_copybutton"]
 experimental = ["llama-index", "rank-bm25", "tree_sitter_languages"]
 
 [tool.ruff]


### PR DESCRIPTION
This fixes the docker image not having the toml dependency. Error most likely introduced here https://github.com/gpt-engineer-org/gpt-engineer/pull/937/files#diff-56bcc43fa5663093cbd7d862ed7849d2e30b13257faed00e09513d88d93d8c45R27

```Traceback (most recent call last):
  File "/usr/local/bin/gpt-engineer", line 5, in <module>
    from gpt_engineer.applications.cli.main import app
  File "/app/gpt_engineer/applications/cli/main.py", line 40, in <module>
    from gpt_engineer.applications.cli.file_selector import FileSelector
  File "/app/gpt_engineer/applications/cli/file_selector.py", line 27, in <module>
    import toml
ModuleNotFoundError: No module named 'toml'
```