### PR TITLE
Fix docs build pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ docs/main
 docs/steps/
 docs/db
 docs/db/
+docs/core/
 
 # coding assistants
 .aider*

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,7 +36,7 @@ with open("../pyproject.toml") as f:
 master_doc = "index"
 
 # General information about the project.
-project = data["project"]["name"]
+project = data["tool"]["poetry"]["name"]
 copyright = "2023 Anton Osika"
 author = " Anton Osika & Contributors"
 
@@ -45,9 +45,9 @@ author = " Anton Osika & Contributors"
 # the built documents.
 #
 # The short X.Y version.
-version = data["project"]["version"]
+version = data["tool"]["poetry"]["version"]
 # The full version, including alpha/beta/rc tags.
-release = data["project"]["version"]
+release = data["tool"]["poetry"]["version"]
 
 
 # -- General configuration ---------------------------------------------


### PR DESCRIPTION
This [commit](https://github.com/gpt-engineer-org/gpt-engineer/commit/e28751f7ce2c943338a460cbf91af19050629348) seems to have broken the build pipeline for the docs. The builds have been failing [for the last 6 weeks](https://readthedocs.org/projects/gpt-engineer/builds/). 

I have tested my changes locally, and I can successfully build the docs. This PR should fix this issue. I also added the docs/core folder to the .gitignore as I noticed it was generated when building the documentation locally. 

I am not entirely about how the docs are being built and deployed - is this done automatically? If so, how?

Thanks!