### PR TITLE
Fix CLI help message

### DIFF
--- a/gpt_engineer/applications/cli/main.py
+++ b/gpt_engineer/applications/cli/main.py
@@ -128,7 +128,7 @@ def main(
         False,
         "--improve",
         "-i",
-        help="Improve files_dict from existing project.",
+        help="Improve mode - improve files_dict from existing project.",
     ),
     lite_mode: bool = typer.Option(
         False,
@@ -140,13 +140,13 @@ def main(
         False,
         "--clarify",
         "-c",
-        help="Lite mode - discuss specification with AI before implementation.",
+        help="Clarify mode - discuss specification with AI before implementation.",
     ),
     self_heal_mode: bool = typer.Option(
         False,
         "--self-heal",
         "-sh",
-        help="Lite mode - discuss specification with AI before implementation.",
+        help="Self-heal mode - fix the code by itself when it fails.",
     ),
     azure_endpoint: str = typer.Option(
         "",


### PR DESCRIPTION
I found that wrong help messages in `gpte --help`.
This pull-request fixes the help messages.