### PR TITLE
feat: added `gpt-engineer.toml` project configuration file

### DIFF
--- a/gpt_engineer/core/project_config.py
+++ b/gpt_engineer/core/project_config.py
@@ -4,7 +4,7 @@ Functions for reading and writing the `gpt-engineer.toml` configuration file.
 The `gpt-engineer.toml` file is a TOML file that contains project-specific configuration used by the GPT Engineer CLI and gptengineer.app.
 """
 
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
 import tomlkit
@@ -74,8 +74,8 @@ def filter_none(d: dict) -> dict:
 class Config:
     """Configuration for the GPT Engineer CLI and gptengineer.app via `gpt-engineer.toml`."""
 
-    project: _ProjectConfig = _ProjectConfig()
-    run: _RunConfig = _RunConfig()
+    project: _ProjectConfig = field(default_factory=_ProjectConfig)
+    run: _RunConfig = field(default_factory=_RunConfig)
     gptengineer_app: _GptEngineerAppConfig | None = None
 
     @classmethod

--- a/gpt_engineer/core/project_config.py
+++ b/gpt_engineer/core/project_config.py
@@ -1,0 +1,159 @@
+"""
+Functions for reading and writing the `gpt-engineer.toml` configuration file.
+
+The `gpt-engineer.toml` file is a TOML file that contains project-specific configuration used by the GPT Engineer CLI and gptengineer.app.
+"""
+
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+import tomlkit
+
+default_config_filename = "gpt-engineer.toml"
+
+example_config = """
+[project]
+base_dir = "./frontend"  # base directory to operate in (for monorepos)
+src_dir = "./src"        # source directory (under the base directory) from which context will be retrieved
+
+[run]
+build = "npm run build"
+test = "npm run test"
+lint = "quick-lint-js"
+
+[gptengineer-app]  # this namespace is used for gptengineer.app, may be used for internal experiments
+project_id = "..."
+
+# we support multiple OpenAPI schemas, used as context for the LLM
+openapi = [
+    { url = "https://api.gptengineer.app/openapi.json" },
+    { url = "https://some-color-translating-api/openapi.json" },
+]
+"""
+
+
+@dataclass
+class _ProjectConfig:
+    base_dir: str | None = None
+    src_dir: str | None = None
+
+
+@dataclass
+class _RunConfig:
+    build: str | None = None
+    test: str | None = None
+    lint: str | None = None
+    format: str | None = None
+
+
+@dataclass
+class _OpenApiConfig:
+    url: str
+
+
+@dataclass
+class _GptEngineerAppConfig:
+    project_id: str
+    openapi: list[_OpenApiConfig] | None = None
+
+
+def filter_none(d: dict) -> dict:
+    # Drop None values and empty dictionaries from a dictionary
+    return {
+        k: v
+        for k, v in (
+            (k, filter_none(v) if isinstance(v, dict) else v)
+            for k, v in d.items()
+            if v is not None
+        )
+        if not (isinstance(v, dict) and not v)  # Check for non-empty after filtering
+    }
+
+
+@dataclass
+class Config:
+    """Configuration for the GPT Engineer CLI and gptengineer.app via `gpt-engineer.toml`."""
+
+    project: _ProjectConfig = _ProjectConfig()
+    run: _RunConfig = _RunConfig()
+    gptengineer_app: _GptEngineerAppConfig | None = None
+
+    @classmethod
+    def from_toml(cls, config_file: Path | str):
+        if isinstance(config_file, str):
+            config_file = Path(config_file)
+        config_dict = read_config(config_file)
+        return cls.from_dict(config_dict)
+
+    @classmethod
+    def from_dict(cls, config_dict: dict):
+        project = _ProjectConfig(**config_dict.get("project", {}))
+        run = _RunConfig(**config_dict.get("run", {}))
+
+        # load optional gptengineer-app section
+        gptengineer_app_dict = config_dict.get("gptengineer-app", {})
+        gptengineer_app = None
+        if gptengineer_app_dict:
+            assert (
+                "project_id" in gptengineer_app_dict
+            ), "project_id is required in gptengineer-app section"
+            gptengineer_app = _GptEngineerAppConfig(
+                # required if gptengineer-app section is present
+                project_id=gptengineer_app_dict["project_id"],
+                openapi=[
+                    _OpenApiConfig(**openapi)
+                    for openapi in gptengineer_app_dict.get("openapi", [])
+                ]
+                or None,
+            )
+
+        return cls(project=project, run=run, gptengineer_app=gptengineer_app)
+
+    def to_dict(self) -> dict:
+        d = asdict(self)
+        d["gptengineer-app"] = d.pop("gptengineer_app", None)
+
+        # Drop None values and empty dictionaries
+        # Needed because tomlkit.dumps() doesn't handle None values,
+        # and we don't want to write empty sections.
+        d = filter_none(d)
+
+        return d
+
+    def to_toml(self, config_file: Path | str, save=True) -> str:
+        """Write the configuration to a TOML file."""
+        if isinstance(config_file, str):
+            config_file = Path(config_file)
+
+        # Load the TOMLDocument and overwrite it with the new values
+        config = read_config(config_file)
+        default_config = Config().to_dict()
+        for k, v in self.to_dict().items():
+            # only write values that are already explicitly set, or that differ from defaults
+            if k in config or v != default_config[k]:
+                if isinstance(v, dict):
+                    config[k] = {
+                        k2: v2
+                        for k2, v2 in v.items()
+                        if (
+                            k2 in config[k]
+                            or default_config.get(k) is None
+                            or v2 != default_config[k].get(k2)
+                        )
+                    }
+                else:
+                    config[k] = v
+
+        toml_str = tomlkit.dumps(config)
+        if save:
+            with open(config_file, "w") as f:
+                f.write(toml_str)
+
+        return toml_str
+
+
+def read_config(config_file: Path) -> tomlkit.TOMLDocument:
+    """Read the configuration file"""
+    assert config_file.exists(), f"Config file {config_file} does not exist"
+    with open(config_file, "r") as f:
+        return tomlkit.load(f)

--- a/gpt_engineer/core/project_config.py
+++ b/gpt_engineer/core/project_config.py
@@ -12,9 +12,9 @@ import tomlkit
 default_config_filename = "gpt-engineer.toml"
 
 example_config = """
-[project]
-base_dir = "./frontend"  # base directory to operate in (for monorepos)
-src_dir = "./src"        # source directory (under the base directory) from which context will be retrieved
+[paths]
+base = "./frontend"  # base directory to operate in (for monorepos)
+src = "./src"        # source directory (under the base directory) from which context will be retrieved
 
 [run]
 build = "npm run build"

--- a/tests/test_project_config.py
+++ b/tests/test_project_config.py
@@ -1,0 +1,144 @@
+import tempfile
+
+import pytest
+
+from gpt_engineer.core.project_config import (
+    Config,
+    _GptEngineerAppConfig,
+    _OpenApiConfig,
+    example_config,
+    filter_none,
+)
+
+
+def test_config_load():
+    # write example config to a file
+    with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
+        f.write(example_config)
+
+    # load the config from the file
+    config = Config.from_toml(f.name)
+
+    assert config.project.base_dir == "./frontend"
+    assert config.project.src_dir == "./src"
+    assert config.run.build == "npm run build"
+    assert config.run.test == "npm run test"
+    assert config.run.lint == "quick-lint-js"
+    assert config.gptengineer_app
+    assert config.gptengineer_app.project_id == "..."
+    assert config.gptengineer_app.openapi
+    assert (
+        config.gptengineer_app.openapi[0].url
+        == "https://api.gptengineer.app/openapi.json"
+    )
+    assert (
+        config.gptengineer_app.openapi[1].url
+        == "https://some-color-translating-api/openapi.json"
+    )
+    assert config.to_dict()
+    assert config.to_toml(f.name, save=False)
+
+    # check that write+read is idempotent
+    assert Config.from_toml(f.name) == config
+
+
+def test_config_defaults():
+    config = Config()
+    assert config.project.base_dir is None
+    with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
+        config.to_toml(f.name)
+
+    # check that read+write is idempotent
+    assert Config.from_toml(f.name) == config
+
+    # check that empty (default) config is written as empty string
+    toml_str = config.to_toml(f.name, save=False)
+    assert toml_str == ""
+
+
+def test_config_from_dict():
+    d = {"gptengineer-app": {"project_id": "..."}}  # minimal example
+    config = Config.from_dict(d)
+    assert config.gptengineer_app
+    assert config.gptengineer_app.project_id == "..."
+    config_dict = config.to_dict()
+
+    # check that the config dict matches the input dict exactly (no keys/defaults added)
+    assert config_dict == d
+
+
+def test_config_from_dict_with_openapi():
+    # A good test because it has 3 levels of nesting
+    d = {
+        "gptengineer-app": {
+            "project_id": "...",
+            "openapi": [
+                {"url": "https://api.gptengineer.app/openapi.json"},
+            ],
+        }
+    }
+    config = Config.from_dict(d)
+    assert config.gptengineer_app
+    assert config.gptengineer_app.project_id == "..."
+    assert config.gptengineer_app.openapi
+    assert (
+        config.gptengineer_app.openapi[0].url
+        == "https://api.gptengineer.app/openapi.json"
+    )
+
+
+def test_config_load_partial():
+    # Loads a partial config, and checks that the rest is not set (i.e. None)
+    example_config = """
+[gptengineer-app]
+project_id = "..."
+""".strip()
+    with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
+        f.write(example_config)
+
+    config = Config.from_toml(f.name)
+    assert config.gptengineer_app
+    assert config.gptengineer_app.project_id == "..."
+    assert config.to_dict()
+    toml_str = config.to_toml(f.name, save=False)
+    assert toml_str == example_config
+
+    # check that write+read is idempotent
+    assert Config.from_toml(f.name) == config
+
+
+def test_config_update():
+    example_config = """
+[gptengineer-app]
+project_id = "..."
+""".strip()
+    with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
+        f.write(example_config)
+    config = Config.from_toml(f.name)
+    config.gptengineer_app = _GptEngineerAppConfig(
+        project_id="...",
+        openapi=[_OpenApiConfig(url="https://api.gptengineer.app/openapi.json")],
+    )
+    config.to_toml(f.name)
+    assert Config.from_toml(f.name) == config
+
+
+@pytest.mark.parametrize(
+    "input_dict,expected",
+    [
+        ({"a": 1, "b": None}, {"a": 1}),
+        ({"a": 1, "b": {"c": None, "d": 2}}, {"a": 1, "b": {"d": 2}}),
+        ({"a": 1, "b": {}}, {"a": 1}),
+        ({"a": 1, "b": {"c": None}}, {"a": 1}),
+        (
+            {"a": {"b": {"c": None}}, "d": {"e": {"f": 2}}, "g": None},
+            {"d": {"e": {"f": 2}}},
+        ),
+        (
+            {"a": 1, "b": {"c": None, "d": {"e": None, "f": {}}}, "g": {"h": 2}},
+            {"a": 1, "g": {"h": 2}},
+        ),
+    ],
+)
+def test_filter_none(input_dict, expected):
+    assert filter_none(input_dict) == expected


### PR DESCRIPTION
Here is an implementation of the proposed `gpt-engineer.toml` configuration file as I mentioned in the last meeting and as discussed in https://github.com/gpt-engineer-org/gpt-engineer/issues/1023

Work is needed to fully integrate/implement use of the configuration.

Comments/review welcome!