### PR TITLE
Updated the readthedocs build steps to account for Poetry 1.8 change regarding virtualenvs behaviour

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,9 +17,8 @@ build:
   jobs:
     post_create_environment:
       - pip install poetry
-      - poetry config virtualenvs.create false
     post_install:
-      - poetry install
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install --with docs
     pre_build:
       - python docs/create_api_rst.py
 


### PR DESCRIPTION
This PR should fix the issue #1050. 

In 1.7, poetry install added packages to the $READTHEDOCS_VIRTUALENV_PATH venv.
In 1.8, packages are added to the underlying Python env, not in the virtualenv.

As a consequence,  the packages added this way are not seen and the build fails. 

The solution is based on [this discussion](https://github.com/python-poetry/poetry/issues/9025#issuecomment-1963073941).