### PR TITLE
ci: added mypy to precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,3 +25,10 @@ repos:
       - id: detect-private-key
       - id: end-of-file-fixer
       - id: trailing-whitespace
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: 'v1.9.0'
+    hooks:
+      - id: mypy
+        args: [--strict, --ignore-missing-imports, --allow-untyped-calls, --allow-untyped-decorators, --allow-untyped-defs, --no-implicit-optional, --no-implicit-reexport]
+        additional_dependencies: []


### PR DESCRIPTION
While trying to get #1057 merged I noticed there were a bunch of type errors that were only caught in tests. I thought we had some kind of typechecking on the codebase, but apparently not.

I added mypy to the precommit config, but it throws 100+ type errors.

Here's the PR anyway, as a reminder we might want to get around to cleaning up the types.