### PR TITLE
Improve `--help` output

### DIFF
--- a/gpt_engineer/applications/cli/main.py
+++ b/gpt_engineer/applications/cli/main.py
@@ -155,7 +155,7 @@ def main(
         False,
         "--improve",
         "-i",
-        help="Improve files_dict from existing project.",
+        help="Improve mode - improve files_dict from existing project.",
     ),
     lite_mode: bool = typer.Option(
         False,
@@ -167,13 +167,13 @@ def main(
         False,
         "--clarify",
         "-c",
-        help="Lite mode - discuss specification with AI before implementation.",
+        help="Clarify mode - discuss specification with AI before implementation.",
     ),
     self_heal_mode: bool = typer.Option(
         False,
         "--self-heal",
         "-sh",
-        help="Lite mode - discuss specification with AI before implementation.",
+        help="Self-heal mode - fix the code by itself when it fails.",
     ),
     azure_endpoint: str = typer.Option(
         "",

--- a/gpt_engineer/applications/cli/main.py
+++ b/gpt_engineer/applications/cli/main.py
@@ -137,7 +137,16 @@ def prompt_yesno(question: str) -> bool:
     return answer in ["y", "yes"]
 
 
-@app.command()
+@app.command(
+    help="""
+        GPT-engineer lets you:
+
+        \b
+        - Specify a software in natural language
+        - Sit back and watch as an AI writes and executes the code
+        - Ask the AI to implement improvements
+    """
+)
 def main(
     project_path: str = typer.Argument("projects/example", help="path"),
     model: str = typer.Argument("gpt-4-1106-preview", help="model id string"),


### PR DESCRIPTION
Fixes #1072

- [x] replace `main()` docstring in `--help` output with a more descriptive description of the application
- [x] correct `--clarify` and `--self-heal` option descriptions (from @hmasdev in #1024)
- [x] unify `--improve`, `--clarify` and `--self-heal` help text formats (from @hmasdev in #1024)