### PR TITLE
add projects/* exception for gitignore filter

### DIFF
--- a/gpt_engineer/applications/cli/file_selector.py
+++ b/gpt_engineer/applications/cli/file_selector.py
@@ -381,7 +381,7 @@ class FileSelector:
 
                 all_files.append(str(relpath))
 
-        if is_git_repo(project_path):
+        if is_git_repo(project_path) and "projects" not in project_path.parts:
             all_files = filter_by_gitignore(project_path, all_files)
 
         return all_files


### PR DESCRIPTION
This hotfix addresses issue #1090, where files expected to be visible in the *file selection* process were missing. The issue stemmed from a recent addition to our Git filtering logic, designed to streamline file management but inadvertently excluding all files within the "projects/*" folder—a common location for users to store temporary project files.

Recognizing the need to maintain both the convenience for users storing projects in the `projects/` folder and the requirement for GPTE developers to avoid unnecessary file uploads, we introduced a specific exception within our filtering logic. This adjustment ensures the `projects/` folder remains unaffected by the filter, thus preserving file visibility.

With this change, the problem highlighted in `file_selector.toml`, where no files were displayed, is effectively resolved. Users can now see all pertinent files under the running directory, ensuring smooth and uninterrupted access to their project files.
