### PR TITLE
Fix potential github action smells

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,11 +3,19 @@ name: Tox pytest all python versions
 on:
   push:
     branches: [ main ]
+    paths:
+      - gpt_engineer/**
+      - tests/**
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{github.workflow}} - ${{github.ref}}
+  cancel-in-progress: true
+
 jobs:
   test:
+    permissions: {}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -23,7 +31,7 @@ jobs:
         cache: 'pip' #Note that pip is for the tox level. Poetry is still used for installing the specific environments (tox.ini)
 
     - name: Install tox
-      run: pip install tox
+      run: pip install tox==4.15.0
 
     - name: Run tox
       env:


### PR DESCRIPTION
Hey! 🙂
I've made the following changes to the workflow:

- Avoid installing packages without version
  - When installing a package without a version, the latest version will always be installed, even when braking changes have been released. To avoid this causing failing pipelines a version should be specified which is known to be compatible with the code base. 
- Define permissions for workflows with external actions
  -  Permissions should be used when running actions written by other developers because there may be security leaks exposed through these actions.
- Avoid running CI related actions when no source code has changed
  -  Running workflows which build or test certain parts of the code base without these parts being changed is useless as nothing new will be checked or created. 
- Stop running workflows when there is a newer commit in PR
  - When a new commit is added to a PR, it is not needed any more to test the old version of the PR because this does not tell us anything about the current state of the PR. Therefore, for efficiency, we can cancel it and only test the latest version. 


(These changes are part of a research Study at TU Delft looking at GitHub Action Smells. [Find out more](https://ceddy4395.github.io/research/gha-smells.html))