### PR TITLE
Add `--sysinfo` CLI Argument to Output System Information for Debugging

### DIFF
--- a/gpt_engineer/applications/cli/main.py
+++ b/gpt_engineer/applications/cli/main.py
@@ -246,7 +246,7 @@ def get_system_info():
         "os_version": platform.version(),
         "architecture": platform.machine(),
         "python_version": sys.version,
-        "packages": format_installed_packages(get_installed_packages())
+        "packages": format_installed_packages(get_installed_packages()),
     }
     return system_info
 

--- a/gpt_engineer/applications/cli/main.py
+++ b/gpt_engineer/applications/cli/main.py
@@ -246,7 +246,7 @@ def get_system_info():
         "os_version": platform.version(),
         "architecture": platform.machine(),
         "python_version": sys.version,
-        "packages": get_installed_packages(),
+        "packages": format_installed_packages(get_installed_packages())
     }
     return system_info
 
@@ -263,6 +263,9 @@ def get_installed_packages():
     except Exception as e:
         return str(e)
 
+
+def format_installed_packages(packages):
+    return "\n".join([f"{name}: {version}" for name, version in packages.items()])
 
 @app.command(
     help="""

--- a/gpt_engineer/applications/cli/main.py
+++ b/gpt_engineer/applications/cli/main.py
@@ -26,12 +26,12 @@ Notes
 """
 
 import difflib
+import json
 import logging
 import os
-import sys
 import platform
 import subprocess
-import json
+import sys
 
 from pathlib import Path
 
@@ -246,13 +246,18 @@ def get_system_info():
         "os_version": platform.version(),
         "architecture": platform.machine(),
         "python_version": sys.version,
-        "packages": get_installed_packages()
+        "packages": get_installed_packages(),
     }
     return system_info
 
+
 def get_installed_packages():
     try:
-        result = subprocess.run([sys.executable, "-m", "pip", "list", "--format=json"], capture_output=True, text=True)
+        result = subprocess.run(
+            [sys.executable, "-m", "pip", "list", "--format=json"],
+            capture_output=True,
+            text=True,
+        )
         packages = json.loads(result.stdout)
         return {pkg["name"]: pkg["version"] for pkg in packages}
     except Exception as e:

--- a/gpt_engineer/applications/cli/main.py
+++ b/gpt_engineer/applications/cli/main.py
@@ -267,6 +267,7 @@ def get_installed_packages():
 def format_installed_packages(packages):
     return "\n".join([f"{name}: {version}" for name, version in packages.items()])
 
+
 @app.command(
     help="""
         GPT-engineer lets you:


### PR DESCRIPTION
This PR addresses #1143 by introducing a new `--sysinfo` command-line argument to the GPT-Engineer CLI tool. The `--sysinfo` argument allows users to output detailed system information for debugging purposes. This information includes the operating system, OS version, system architecture, Python version, and installed Python packages.

#### Changes Include:
- **New Functionality**:
  - Added a `--sysinfo` option to the Typer CLI in `main.py`.
  - Implemented `get_system_info` and `get_installed_packages` functions to gather and format system information.
- **File Modifications**:
  - Updated `main.py` to include the `--sysinfo` option and corresponding logic.

#### Usage:
To use the new `--sysinfo` feature, run the following command:
```sh
python main.py --sysinfo
```
This will display the following information:
- Operating System and Version
- System Architecture
- Python Version
- Installed Python Packages and their Versions

#### Example Output:
```sh
os: Linux
os_version: #1 SMP Wed Dec 15 10:30:14 UTC 2021
architecture: x86_64
python_version: 3.10.2 (default, Jan 14 2022, 00:00:00) [GCC 7.5.0]
packages: {"typer": "0.4.0", "openai": "0.10.1", ...}
```

#### Notes:
- This addition aims to help users and developers quickly gather essential system information, facilitating easier debugging and support.

Please review the changes and provide feedback. Thank you!