### PR TITLE
fixing tox Python 3.11 and 3.12 issues

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ on:
     branches: [ main ]
 
 concurrency:
-  group: ${{github.workflow}} - ${{github.ref}}
+  group: ${{ github.workflow }} - ${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -30,8 +30,10 @@ jobs:
         python-version: ${{ matrix.python-version }}
         cache: 'pip' #Note that pip is for the tox level. Poetry is still used for installing the specific environments (tox.ini)
 
-    - name: Install tox
-      run: pip install tox==4.15.0
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install tox==4.15.0 poetry
 
     - name: Run tox
       env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,20 +15,23 @@ concurrency:
 
 jobs:
   test:
-    permissions: {}
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ['3.10', '3.11', '3.12']
 
     steps:
-    - uses: actions/checkout@v3
+    - name: Checkout repository
+      uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-        cache: 'pip' #Note that pip is for the tox level. Poetry is still used for installing the specific environments (tox.ini)
+        cache: 'pip'  #Note that pip is for the tox level. Poetry is still used for installing the specific environments (tox.ini)
+
+    - name: Check Python Version
+      run: python --version
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,8 +27,8 @@ jobs:
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
-        python-version: ${{ matrix.python-version }}
-        cache: 'pip'  #Note that pip is for the tox level. Poetry is still used for installing the specific environments (tox.ini)
+        python-version: ${{ matrix.python-version == '3.12' && '3.12.3' || matrix.python-version }} # Using 3.12.3 to resolve Pydantic ForwardRef issue
+        cache: 'pip'  # Note that pip is for the tox level. Poetry is still used for installing the specific environments (tox.ini)
 
     - name: Check Python Version
       run: python --version
@@ -43,6 +43,7 @@ jobs:
         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       run: tox
 
+    # Temporarily disabling codecov until we resolve codecov rate limiting issue
     # - name: Report coverage
     #   run: |
     #     bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,6 +43,6 @@ jobs:
         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       run: tox
 
-    - name: Report coverage
-      run: |
-        bash <(curl -s https://codecov.io/bash)
+    # - name: Report coverage
+    #   run: |
+    #     bash <(curl -s https://codecov.io/bash)

--- a/tox.ini
+++ b/tox.ini
@@ -9,5 +9,5 @@ basepython =
 deps =
     poetry
 commands =
-    poetry install
+    poetry install --no-root
     poetry run pytest --cov=gpt_engineer --cov-report=xml -k 'not installed_main_execution'

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,13 @@
 [tox]
 envlist = py310, py311, py312
-isolated_build = True
 
 [testenv]
+basepython =
+    py310: python3.10
+    py311: python3.11
+    py312: python3.12
 deps =
     poetry
 commands =
     poetry install
-    poetry run pytest --cov=gpt_engineer --cov-report=xml -k "not installed_main_execution"
-passenv =
-    OPENAI_API_KEY
+    poetry run pytest --cov=gpt_engineer --cov-report=xml -k 'not installed_main_execution'


### PR DESCRIPTION
Python 3.11 target doesn't run in `tox`. Fixing this.