### PR TITLE
Update bug report template to include installation method

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -30,3 +30,7 @@ If your project includes a debug_log_file.txt, kindly upload it from your_projec
 ## System Information
 
 Please copy and paste the output of the `gpte --sysinfo` command as part of your bug report.
+
+## Installation Method
+
+Please specify whether you installed GPT-Engineer using `pip install` or by building the repository.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -19,6 +19,10 @@ This is the preferred method to install ``gpt-engineer``, as it will always inst
 If you don't have `pip`_ installed, this `Python installation guide`_ can guide
 you through the process.
 
+.. note::
+
+    When reporting bugs, please specify your installation method (using `pip install` or by building the repository) in the "Installation Method" section of the bug report template.
+
 .. _pip: https://pip.pypa.io
 .. _Python installation guide: http://docs.python-guide.org/en/latest/starting/installation/
 


### PR DESCRIPTION
Update the bug report issue template to ask the user to report how they installed GPT-Engineer.

* **Bug Report Template**:
  - Add a new section titled "Installation Method" after the "System Information" section.
  - Ask users to specify whether they installed GPT-Engineer using `pip install` or by building the repository.

* **Installation Documentation**:
  - Add a note to the "Stable release" section to mention the new "Installation Method" section in the bug report template.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/gpt-engineer-org/gpt-engineer?shareId=8d0134c6-49f6-4489-9857-f983af7c21ac).